### PR TITLE
Replace web view with native Raspberry Pi dashboard

### DIFF
--- a/RoomPi/ContentView.swift
+++ b/RoomPi/ContentView.swift
@@ -1,211 +1,620 @@
-//
-//  ContentView.swift
-//  RoomPi
-//
-//  Created by Michał Grzesiewicz on 24/09/2025.
-//
-
-#Preview {
-    ContentView()
-}
-
 import SwiftUI
-import WebKit
-import Combine
-import SafariServices
 
-// MARK: - Konfiguracja: ustaw tutaj adres Twojej aplikacji webowej
 private let BASE_URL = URL(string: "http://192.168.0.151")!
 
-// MARK: - ViewModel do obserwacji tytułu, progresu i nawigacji
-final class WebViewModel: ObservableObject {
-    @Published var canGoBack = false
-    @Published var canGoForward = false
-    @Published var isLoading = false
-    @Published var progress: Double = 0.0
-    @Published var title: String = "Ładowanie…"
-    fileprivate var webView: WKWebView? // ustawiane po inicjalizacji
-}
-
-// MARK: - Wrapper WKWebView
-struct WebView: UIViewRepresentable {
-    @ObservedObject var model: WebViewModel
-    let url: URL
-    
-    func makeCoordinator() -> Coordinator { Coordinator(self) }
-    
-    func makeUIView(context: Context) -> WKWebView {
-        let config = WKWebViewConfiguration()
-        config.allowsInlineMediaPlayback = true
-        config.limitsNavigationsToAppBoundDomains = false
-        // WebRTC / getUserMedia w WKWebView wymaga tego domyślnego configu (i opisów w Info.plist)
-        
-        let webView = WKWebView(frame: .zero, configuration: config)
-        webView.navigationDelegate = context.coordinator
-        webView.uiDelegate = context.coordinator
-        webView.allowsBackForwardNavigationGestures = true
-        webView.scrollView.bounces = true
-        
-        // Pull to refresh
-        let refresh = UIRefreshControl()
-        refresh.addTarget(context.coordinator, action: #selector(Coordinator.refresh(_:)), for: .valueChanged)
-        webView.scrollView.refreshControl = refresh
-        
-        // KVO do progresu
-        webView.addObserver(context.coordinator, forKeyPath: #keyPath(WKWebView.estimatedProgress), options: .new, context: nil)
-        webView.addObserver(context.coordinator, forKeyPath: #keyPath(WKWebView.canGoBack), options: .new, context: nil)
-        webView.addObserver(context.coordinator, forKeyPath: #keyPath(WKWebView.canGoForward), options: .new, context: nil)
-        webView.addObserver(context.coordinator, forKeyPath: #keyPath(WKWebView.title), options: .new, context: nil)
-        webView.addObserver(context.coordinator, forKeyPath: "loading", options: .new, context: nil)
-        
-        webView.load(URLRequest(url: url))
-        model.webView = webView
-        return webView
-    }
-    
-    func updateUIView(_ webView: WKWebView, context: Context) { }
-    
-    // MARK: - Coordinator
-    final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
-        let parent: WebView
-        init(_ parent: WebView) { self.parent = parent }
-        
-        // Pull to refresh handler
-        @objc func refresh(_ sender: UIRefreshControl) {
-            parent.model.webView?.reload()
-        }
-        
-        // KVO
-        override func observeValue(forKeyPath keyPath: String?, of object: Any?,
-                                   change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-            guard let webView = object as? WKWebView else { return }
-            DispatchQueue.main.async {
-                switch keyPath {
-                case #keyPath(WKWebView.estimatedProgress):
-                    self.parent.model.progress = webView.estimatedProgress
-                    self.parent.model.isLoading = webView.estimatedProgress < 1.0
-                case #keyPath(WKWebView.canGoBack):
-                    self.parent.model.canGoBack = webView.canGoBack
-                case #keyPath(WKWebView.canGoForward):
-                    self.parent.model.canGoForward = webView.canGoForward
-                case #keyPath(WKWebView.title):
-                    self.parent.model.title = webView.title ?? ""
-                case "loading":
-                    self.parent.model.isLoading = webView.isLoading
-                    if !webView.isLoading {
-                        webView.scrollView.refreshControl?.endRefreshing()
-                    }
-                default: break
-                }
-            }
-        }
-        
-        // Obsługa nawigacji i linków zewnętrznych
-        func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
-                     decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-            guard let url = navigationAction.request.url else {
-                decisionHandler(.cancel); return
-            }
-            
-            // Zezwól na http(s) do naszego hosta i pod-ścieżek
-            if url.scheme?.hasPrefix("http") == true {
-                decisionHandler(.allow)
-                return
-            }
-            
-            // Obsłuż schematy tel:, mailto:, itp. otwierając system
-            if UIApplication.shared.canOpenURL(url) {
-                UIApplication.shared.open(url)
-                decisionHandler(.cancel)
-                return
-            }
-            
-            decisionHandler(.allow)
-        }
-        
-        // target="_blank" → otwórz w tym samym webview (albo zewnętrznie po chęci)
-        func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration,
-                     for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
-            if navigationAction.targetFrame == nil {
-                webView.load(navigationAction.request)
-            }
-            return nil
-        }
-        
-        func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-            parent.model.isLoading = true
-        }
-        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            parent.model.isLoading = false
-            webView.scrollView.refreshControl?.endRefreshing()
-        }
-        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-            parent.model.isLoading = false
-            webView.scrollView.refreshControl?.endRefreshing()
-        }
-        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-            parent.model.isLoading = false
-            webView.scrollView.refreshControl?.endRefreshing()
-        }
-    }
-}
-
-// MARK: - Główny widok z paskiem narzędzi
 struct ContentView: View {
-    @StateObject private var model = WebViewModel()
-    @State private var showingShare = false
-    
+    @StateObject private var viewModel: StatusDashboardViewModel
+    @State private var selectedMetric: HistoryMetric = .cpuTemperature
+
+    init(viewModel: StatusDashboardViewModel = StatusDashboardViewModel(service: StatusService(baseURL: BASE_URL))) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
     var body: some View {
         NavigationView {
-            ZStack(alignment: .top) {
-                WebView(model: model, url: BASE_URL)
-                    .ignoresSafeArea(edges: .bottom)
-                
-                // Pasek postępu
-                if model.isLoading {
-                    ProgressView(value: model.progress)
-                        .progressViewStyle(.linear)
-                        .padding(.top, 1)
+            ZStack {
+                Color(.systemGroupedBackground).ignoresSafeArea()
+
+                Group {
+                    if let bundle = viewModel.bundle {
+                        ScrollView {
+                            VStack(alignment: .leading, spacing: 24) {
+                                headerSection(for: bundle)
+
+                                if let error = viewModel.errorMessage {
+                                    ErrorBanner(text: error)
+                                }
+
+                                MetricsGrid(snapshot: bundle.snapshot)
+
+                                if bundle.history.enabled {
+                                    HistorySection(history: bundle.history, selectedMetric: $selectedMetric)
+                                }
+
+                                ServicesSection(services: bundle.snapshot.services)
+
+                                ShellySection(payload: bundle.shelly)
+                            }
+                            .padding(.horizontal)
+                            .padding(.vertical, 24)
+                        }
+                        .refreshable { await viewModel.manualRefresh() }
+                    } else {
+                        placeholderView
+                    }
                 }
             }
-            .navigationTitle(model.title.isEmpty ? "RaspberryPi" : model.title)
-            .navigationBarTitleDisplayMode(.inline)
+            .navigationTitle("Panel Raspberry Pi")
             .toolbar {
-                ToolbarItemGroup(placement: .bottomBar) {
-                    Button(action: { model.webView?.goBack() }) {
-                        Image(systemName: "chevron.backward")
-                    }.disabled(!model.canGoBack)
-                    
-                    Button(action: { model.webView?.goForward() }) {
-                        Image(systemName: "chevron.forward")
-                    }.disabled(!model.canGoForward)
-                    
-                    Spacer()
-                    
-                    Button(action: { model.webView?.reload() }) {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        Task { await viewModel.manualRefresh() }
+                    } label: {
                         Image(systemName: "arrow.clockwise")
                     }
-                    
-                    Button(action: {
-                        guard let url = model.webView?.url else { return }
-                        let av = UIActivityViewController(activityItems: [url], applicationActivities: nil)
-                        if let scene = UIApplication.shared.connectedScenes
-                            .compactMap({ $0 as? UIWindowScene })
-                            .first(where: { $0.activationState == .foregroundActive }),
-                           let root = scene.windows.first(where: { $0.isKeyWindow })?.rootViewController {
-                            if let popover = av.popoverPresentationController {
-                                popover.sourceView = root.view
-                                popover.sourceRect = CGRect(x: root.view.bounds.midX, y: root.view.bounds.midY, width: 0, height: 0)
-                                popover.permittedArrowDirections = []
-                            }
-                            root.present(av, animated: true)
-                        }
-                    }) {
-                        Image(systemName: "square.and.arrow.up")
-                    }
+                    .disabled(viewModel.isLoading)
+                    .accessibilityLabel("Odśwież dane")
                 }
+            }
+        }
+        .navigationViewStyle(.stack)
+        .task { viewModel.start() }
+        .onDisappear { viewModel.stop() }
+    }
+
+    @ViewBuilder
+    private func headerSection(for bundle: StatusBundle) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Status Raspberry Pi")
+                .font(.title)
+                .fontWeight(.bold)
+
+            if let lastUpdate = viewModel.lastUpdate {
+                Label {
+                    Text("Ostatnia aktualizacja: \(Formatters.fullDate.string(from: lastUpdate)) (") + Text(Formatters.relativeFormatter.localizedString(for: lastUpdate, relativeTo: Date())).italic() + Text(")")
+                } icon: {
+                    Image(systemName: "clock.arrow.2.circlepath")
+                        .foregroundColor(.accentColor)
+                }
+                .font(.subheadline)
+                .foregroundStyle(.primary)
+            } else if viewModel.isLoading {
+                Label("Ładowanie pierwszych danych…", systemImage: "clock.arrow.2.circlepath")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let generatedAt = bundle.snapshot.generatedAt {
+                Label("Czas serwera: \(Formatters.time.string(from: generatedAt))", systemImage: "network")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            } else if let time = bundle.snapshot.time {
+                Label("Czas serwera: \(time)", systemImage: "network")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+
+            Text("Automatyczne odświeżanie co \(bundle.streamInterval) s")
+                .font(.footnote)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var placeholderView: some View {
+        VStack(spacing: 20) {
+            if viewModel.isLoading {
+                ProgressView("Ładowanie danych…")
+                    .progressViewStyle(.circular)
+                    .tint(.accentColor)
+            } else {
+                Image(systemName: "antenna.radiowaves.left.and.right")
+                    .font(.system(size: 48))
+                    .foregroundColor(.accentColor)
+
+                Text("Brak danych do wyświetlenia")
+                    .font(.headline)
+
+                Text(viewModel.errorMessage ?? "Połącz się z Raspberry Pi, aby zobaczyć aktualny stan urządzenia.")
+                    .font(.subheadline)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal)
+
+                Button {
+                    Task { await viewModel.manualRefresh() }
+                } label: {
+                    Label("Spróbuj ponownie", systemImage: "arrow.clockwise")
+                        .fontWeight(.semibold)
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 12)
+                        .background(Capsule().fill(Color.accentColor.opacity(0.1)))
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+private struct MetricsGrid: View {
+    let snapshot: StatusSnapshot
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Label("Kluczowe metryki", systemImage: "chart.bar")
+                .font(.headline)
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 160), spacing: 16)], spacing: 16) {
+                MetricCard(title: "Temperatura CPU", value: snapshot.cpuTemperature ?? "Brak danych", systemImage: "thermometer.medium", tint: .red)
+                MetricCard(title: "Pamięć RAM", value: snapshot.memoryUsage ?? "Brak danych", systemImage: "memorychip", tint: .blue)
+                MetricCard(title: "Miejsce na dysku", value: snapshot.diskUsage ?? "Brak danych", systemImage: "internaldrive", tint: .teal)
+                MetricCard(title: "Obciążenie", value: snapshot.systemLoad ?? "Brak danych", systemImage: "gauge", tint: .orange)
+                MetricCard(title: "Czas działania", value: snapshot.uptime ?? "Brak danych", systemImage: "clock", tint: .purple)
             }
         }
     }
 }
 
+private struct MetricCard: View {
+    let title: String
+    let value: String
+    let systemImage: String
+    let tint: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(title, systemImage: systemImage)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(tint)
+
+            Text(value)
+                .font(.title3)
+                .fontWeight(.semibold)
+                .foregroundColor(.primary)
+                .lineLimit(2)
+                .minimumScaleFactor(0.7)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 18, style: .continuous).fill(Color(.secondarySystemBackground)))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color(.quaternaryLabel), lineWidth: 0.6)
+        )
+    }
+}
+
+private struct HistorySection: View {
+    let history: HistoryPayload
+    @Binding var selectedMetric: HistoryMetric
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Label("Historia metryk", systemImage: "chart.line.uptrend.xyaxis")
+                .font(.headline)
+
+            if history.isAvailable {
+                Picker("Metryka", selection: $selectedMetric) {
+                    ForEach(HistoryMetric.allCases) { metric in
+                        Label(metric.title, systemImage: metric.symbolName)
+                            .tag(metric)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                HistoryChartView(entries: history.entries, metric: selectedMetric)
+                    .frame(height: 220)
+
+                if let latest = history.entries.last,
+                   let label = selectedMetric.formattedLabel(from: latest) {
+                    Text("Ostatnia wartość: \(label)")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                }
+            } else {
+                Text("Historia została wyłączona lub nie zawiera jeszcze danych.")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 18, style: .continuous).fill(Color(.secondarySystemBackground)))
+    }
+}
+
+private struct HistoryChartView: View {
+    struct DataPoint: Identifiable {
+        let id = UUID()
+        let date: Date
+        let value: Double
+    }
+
+    let entries: [HistoryEntry]
+    let metric: HistoryMetric
+
+    private var points: [DataPoint] {
+        entries.compactMap { entry -> DataPoint? in
+            guard let date = entry.generatedAt ?? Formatters.historyFallbackDate(from: entry.time),
+                  let value = metric.numericValue(from: entry) else {
+                return nil
+            }
+            return DataPoint(date: date, value: value)
+        }
+        .sorted { $0.date < $1.date }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if points.count >= 2 {
+                GeometryReader { geometry in
+                    let normalized = normalizedPoints(in: geometry.size)
+
+                    ZStack {
+                        areaPath(from: normalized, in: geometry.size)
+                            .fill(metric.accentColor.opacity(0.18))
+
+                        linePath(from: normalized)
+                            .stroke(metric.accentColor, style: StrokeStyle(lineWidth: 2, lineJoin: .round, lineCap: .round))
+
+                        ForEach(Array(normalized.enumerated()), id: \.offset) { element in
+                            Circle()
+                                .fill(metric.accentColor)
+                                .frame(width: 6, height: 6)
+                                .position(element.element)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+                .frame(height: 180)
+
+                if let first = points.first, let last = points.last {
+                    HStack {
+                        Text(Formatters.chartAxis.string(from: first.date))
+                        Spacer()
+                        Text(Formatters.chartAxis.string(from: last.date))
+                    }
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                }
+            } else {
+                Text("Za mało danych, aby narysować wykres dla tej metryki.")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    private func normalizedPoints(in size: CGSize) -> [CGPoint] {
+        guard !points.isEmpty else { return [] }
+
+        let minValue = points.map(\.value).min() ?? 0
+        let maxValue = points.map(\.value).max() ?? minValue
+        let valueRange = max(maxValue - minValue, 0.001)
+
+        guard let firstDate = points.first?.date else { return [] }
+        let lastDate = points.last?.date ?? firstDate
+        let timeRange = max(lastDate.timeIntervalSince(firstDate), 1)
+
+        return points.enumerated().map { index, point in
+            let relativeX: CGFloat
+            if timeRange == 0 {
+                relativeX = points.count > 1
+                    ? CGFloat(index) / CGFloat(points.count - 1)
+                    : 0
+            } else {
+                relativeX = CGFloat(point.date.timeIntervalSince(firstDate) / timeRange)
+            }
+
+            let relativeY: CGFloat
+            if valueRange == 0 {
+                relativeY = 0.5
+            } else {
+                relativeY = CGFloat((point.value - minValue) / valueRange)
+            }
+
+            let x = relativeX * size.width
+            let y = size.height * (1 - relativeY)
+            return CGPoint(x: x, y: y)
+        }
+    }
+
+    private func linePath(from points: [CGPoint]) -> Path {
+        var path = Path()
+        guard let first = points.first else { return path }
+        path.move(to: first)
+        for point in points.dropFirst() {
+            path.addLine(to: point)
+        }
+        return path
+    }
+
+    private func areaPath(from points: [CGPoint], in size: CGSize) -> Path {
+        var path = Path()
+        guard let first = points.first, let last = points.last else { return path }
+        path.move(to: CGPoint(x: first.x, y: size.height))
+        path.addLine(to: first)
+        for point in points.dropFirst() {
+            path.addLine(to: point)
+        }
+        path.addLine(to: CGPoint(x: last.x, y: size.height))
+        path.closeSubpath()
+        return path
+    }
+}
+
+private struct ServicesSection: View {
+    let services: [ServiceStatus]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Label("Usługi systemowe", systemImage: "server.rack")
+                .font(.headline)
+
+            if services.isEmpty {
+                Text("Brak skonfigurowanych usług do monitorowania.")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            } else {
+                ForEach(services) { service in
+                    ServiceRow(service: service)
+
+                    if service.id != services.last?.id {
+                        Divider()
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 18, style: .continuous).fill(Color(.secondarySystemBackground)))
+    }
+}
+
+private struct ServiceRow: View {
+    let service: ServiceStatus
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(service.label)
+                        .font(.subheadline.weight(.semibold))
+                    Text(service.service)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                StatusBadge(text: service.status, color: service.statusColor)
+            }
+
+            if let details = service.details, !details.isEmpty {
+                Text(details)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+}
+
+private struct ShellySection: View {
+    let payload: ShellyPayload
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Label("Urządzenia Shelly", systemImage: "bolt.horizontal.circle")
+                .font(.headline)
+
+            if payload.configError {
+                WarningBox(text: "Wykryto problem w konfiguracji modułu Shelly. Sprawdź plik config/shelly.php na serwerze.")
+            }
+
+            if let message = payload.message {
+                WarningBox(text: message)
+            } else if payload.hasErrors {
+                WarningBox(text: "Niektóre urządzenia zwróciły błędy. Szczegóły znajdziesz poniżej.", style: .caution)
+            }
+
+            if payload.devices.isEmpty {
+                Text("Brak skonfigurowanych urządzeń Shelly.")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            } else {
+                ForEach(payload.devices) { device in
+                    ShellyRow(device: device)
+
+                    if device.id != payload.devices.last?.id {
+                        Divider()
+                    }
+                }
+            }
+
+            Text("Przełączanie przekaźników wymaga tokenu CSRF z panelu WWW – aplikacja prezentuje tylko odczyty stanu.")
+                .font(.footnote)
+                .foregroundColor(.secondary)
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 18, style: .continuous).fill(Color(.secondarySystemBackground)))
+    }
+}
+
+private struct ShellyRow: View {
+    let device: ShellyDevice
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(device.label)
+                        .font(.subheadline.weight(.semibold))
+                    Text(device.description ?? device.state.capitalized)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                StatusBadge(text: device.ok ? "OK" : "Błąd", color: device.ok ? .green : .orange)
+            }
+
+            if let error = device.error, !error.isEmpty {
+                Text(error)
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+        }
+    }
+}
+
+private struct StatusBadge: View {
+    let text: String
+    let color: Color
+
+    var body: some View {
+        Text(text)
+            .font(.caption.weight(.semibold))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(RoundedRectangle(cornerRadius: 12, style: .continuous).fill(color.opacity(0.15)))
+            .foregroundColor(color)
+    }
+}
+
+private struct ErrorBanner: View {
+    let text: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(.yellow)
+                .imageScale(.large)
+
+            Text(text)
+                .font(.subheadline)
+                .foregroundColor(.primary)
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 18, style: .continuous).fill(Color(.systemYellow).opacity(0.18)))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color(.systemYellow).opacity(0.5), lineWidth: 1)
+        )
+    }
+}
+
+private struct WarningBox: View {
+    enum Style {
+        case warning
+        case caution
+
+        var color: Color {
+            switch self {
+            case .warning: return .yellow
+            case .caution: return .orange
+            }
+        }
+    }
+
+    let text: String
+    var style: Style = .warning
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Image(systemName: "exclamationmark.circle")
+                .foregroundColor(style.color)
+            Text(text)
+                .font(.footnote)
+                .foregroundColor(.secondary)
+        }
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 12, style: .continuous).fill(style.color.opacity(0.12)))
+    }
+}
+
+private enum Formatters {
+    static let relativeFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        return formatter
+    }()
+
+    static let time: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .medium
+        return formatter
+    }()
+
+    static let fullDate: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    static let chartAxis: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    private static let historyTime: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "HH:mm:ss"
+        formatter.timeZone = .current
+        return formatter
+    }()
+
+    static func historyFallbackDate(from timeLabel: String?) -> Date? {
+        guard let timeLabel, !timeLabel.isEmpty,
+              let timeDate = historyTime.date(from: timeLabel) else { return nil }
+
+        let calendar = Calendar.current
+        let dayComponents = calendar.dateComponents([.year, .month, .day], from: Date())
+        let timeComponents = calendar.dateComponents([.hour, .minute, .second], from: timeDate)
+
+        var merged = DateComponents()
+        merged.year = dayComponents.year
+        merged.month = dayComponents.month
+        merged.day = dayComponents.day
+        merged.hour = timeComponents.hour
+        merged.minute = timeComponents.minute
+        merged.second = timeComponents.second
+
+        return calendar.date(from: merged)
+    }
+}
+
+private extension HistoryMetric {
+    var accentColor: Color {
+        switch self {
+        case .cpuTemperature:
+            return .red
+        case .memoryUsage:
+            return .blue
+        case .diskUsage:
+            return .teal
+        case .systemLoad:
+            return .orange
+        }
+    }
+}
+
+private extension ServiceStatus {
+    var statusColor: Color {
+        if cssClass.contains("ok") { return .green }
+        if cssClass.contains("error") { return .red }
+        if cssClass.contains("warn") { return .orange }
+        if cssClass.contains("off") { return .gray }
+        return .secondary
+    }
+}
+
+#Preview {
+    ContentView(viewModel: StatusDashboardViewModel(
+        service: StatusService(baseURL: BASE_URL),
+        initialBundle: .preview
+    ))
+}

--- a/RoomPi/StatusDashboardViewModel.swift
+++ b/RoomPi/StatusDashboardViewModel.swift
@@ -1,0 +1,94 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class StatusDashboardViewModel: ObservableObject {
+    @Published private(set) var bundle: StatusBundle?
+    @Published private(set) var isLoading = false
+    @Published private(set) var errorMessage: String?
+    @Published private(set) var lastUpdate: Date?
+
+    private let service: StatusService
+    private let historyLimit: Int
+    private let fallbackInterval: TimeInterval
+    private var autoRefreshTask: Task<Void, Never>?
+
+    init(service: StatusService, historyLimit: Int = 120, fallbackInterval: TimeInterval = 5, initialBundle: StatusBundle? = nil) {
+        self.service = service
+        self.historyLimit = historyLimit
+        self.fallbackInterval = fallbackInterval
+        self.bundle = initialBundle
+        self.lastUpdate = initialBundle?.serverDate ?? initialBundle?.generatedAt
+    }
+
+    deinit {
+        stop()
+    }
+
+    func start() {
+        guard autoRefreshTask == nil else { return }
+
+        autoRefreshTask = Task { [weak self] in
+            while let self, !Task.isCancelled {
+                await self.refresh()
+
+                let interval = self.bundle.map { TimeInterval($0.streamInterval) } ?? self.fallbackInterval
+                let clampedInterval = interval.clamped(to: 1...60)
+
+                try? await Task.sleep(nanoseconds: UInt64(clampedInterval * 1_000_000_000))
+            }
+        }
+    }
+
+    func stop() {
+        autoRefreshTask?.cancel()
+        autoRefreshTask = nil
+    }
+
+    func manualRefresh() async {
+        await refresh()
+    }
+
+    private func refresh() async {
+        if isLoading { return }
+
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            let response = try await service.fetchStatusBundle(historyLimit: historyLimit)
+
+            withAnimation(.easeInOut(duration: 0.2)) {
+                bundle = response
+                errorMessage = nil
+            }
+
+            lastUpdate = response.serverDate ?? response.generatedAt ?? Date()
+        } catch is CancellationError {
+            // Ignore task cancellations triggered by lifecycle events.
+        } catch {
+            errorMessage = userFriendlyMessage(for: error)
+        }
+    }
+
+    private func userFriendlyMessage(for error: Error) -> String {
+        if let serviceError = error as? StatusService.ServiceError {
+            return serviceError.localizedDescription
+        }
+
+        if let urlError = error as? URLError {
+            return urlError.localizedDescription
+        }
+
+        return error.localizedDescription.isEmpty
+            ? "Wystąpił nieoczekiwany błąd."
+            : error.localizedDescription
+    }
+}
+
+private extension TimeInterval {
+    func clamped(to range: ClosedRange<TimeInterval>) -> TimeInterval {
+        min(max(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/RoomPi/StatusModels.swift
+++ b/RoomPi/StatusModels.swift
@@ -1,0 +1,263 @@
+import Foundation
+
+struct StatusBundle: Decodable, Equatable {
+    let generatedAt: Date?
+    let streamInterval: Int
+    let snapshot: StatusSnapshot
+    let history: HistoryPayload
+    let shelly: ShellyPayload
+
+    var serverDate: Date? {
+        snapshot.generatedAt ?? generatedAt
+    }
+}
+
+struct StatusSnapshot: Decodable, Equatable {
+    let time: String?
+    let generatedAt: Date?
+    let cpuTemperature: String?
+    let systemLoad: String?
+    let uptime: String?
+    let memoryUsage: String?
+    let diskUsage: String?
+    let services: [ServiceStatus]
+}
+
+struct ServiceStatus: Decodable, Identifiable, Equatable {
+    let id: String
+    let label: String
+    let service: String
+    let status: String
+    let cssClass: String
+    let details: String?
+
+    init(id: String, label: String, service: String, status: String, cssClass: String, details: String?) {
+        self.id = id
+        self.label = label
+        self.service = service
+        self.status = status
+        self.cssClass = cssClass
+        self.details = details
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let label = try container.decode(String.self, forKey: .label)
+        let service = try container.decode(String.self, forKey: .service)
+        let status = try container.decode(String.self, forKey: .status)
+        let cssClass = (try? container.decode(String.self, forKey: .cssClass)) ?? "status-unknown"
+        let details = try? container.decodeIfPresent(String.self, forKey: .details)
+
+        self.label = label
+        self.service = service
+        self.status = status
+        self.cssClass = cssClass
+        self.details = details
+        self.id = service.isEmpty ? label : service
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case label
+        case service
+        case status
+        case cssClass = "class"
+        case details
+    }
+}
+
+struct HistoryPayload: Decodable, Equatable {
+    let generatedAt: Date?
+    let enabled: Bool
+    let maxEntries: Int
+    let maxAge: Int?
+    let count: Int
+    let limit: Int?
+    let entries: [HistoryEntry]
+
+    var isAvailable: Bool {
+        enabled && !entries.isEmpty
+    }
+}
+
+struct HistoryEntry: Decodable, Identifiable, Equatable {
+    struct TemperatureMetric: Decodable, Equatable {
+        let value: Double?
+        let label: String?
+    }
+
+    struct PercentageMetric: Decodable, Equatable {
+        let percentage: Double?
+        let label: String?
+    }
+
+    struct SystemLoadMetric: Decodable, Equatable {
+        let one: Double?
+        let five: Double?
+        let fifteen: Double?
+        let label: String?
+    }
+
+    let generatedAt: Date?
+    let time: String?
+    let cpuTemperature: TemperatureMetric
+    let memoryUsage: PercentageMetric
+    let diskUsage: PercentageMetric
+    let systemLoad: SystemLoadMetric
+
+    var id: String {
+        if let generatedAt {
+            return String(generatedAt.timeIntervalSince1970)
+        }
+        if let time {
+            return time
+        }
+        return UUID().uuidString
+    }
+}
+
+struct ShellyPayload: Decodable, Equatable {
+    let generatedAt: Date?
+    let count: Int
+    let hasErrors: Bool
+    let devices: [ShellyDevice]
+    let configError: Bool
+    let httpStatus: Int?
+    let error: String?
+    let message: String?
+}
+
+struct ShellyDevice: Decodable, Identifiable, Equatable {
+    let id: String
+    let label: String
+    let state: String
+    let description: String?
+    let error: String?
+    let ok: Bool
+}
+
+enum HistoryMetric: String, CaseIterable, Identifiable {
+    case cpuTemperature
+    case memoryUsage
+    case diskUsage
+    case systemLoad
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .cpuTemperature:
+            return "Temperatura"
+        case .memoryUsage:
+            return "Pamięć"
+        case .diskUsage:
+            return "Dysk"
+        case .systemLoad:
+            return "Obciążenie"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .cpuTemperature:
+            return "thermometer.medium"
+        case .memoryUsage:
+            return "memorychip"
+        case .diskUsage:
+            return "internaldrive"
+        case .systemLoad:
+            return "gauge"
+        }
+    }
+
+    func numericValue(from entry: HistoryEntry) -> Double? {
+        switch self {
+        case .cpuTemperature:
+            return entry.cpuTemperature.value
+        case .memoryUsage:
+            return entry.memoryUsage.percentage
+        case .diskUsage:
+            return entry.diskUsage.percentage
+        case .systemLoad:
+            return entry.systemLoad.one
+        }
+    }
+
+    func formattedLabel(from entry: HistoryEntry) -> String? {
+        switch self {
+        case .cpuTemperature:
+            return entry.cpuTemperature.label
+        case .memoryUsage:
+            return entry.memoryUsage.label
+        case .diskUsage:
+            return entry.diskUsage.label
+        case .systemLoad:
+            return entry.systemLoad.label
+        }
+    }
+}
+
+extension StatusBundle {
+    static var preview: StatusBundle {
+        let now = Date()
+        let services = [
+            ServiceStatus(id: "nginx.service", label: "Nginx", service: "nginx.service", status: "Aktywna", cssClass: "status-ok", details: nil),
+            ServiceStatus(id: "php-fpm.service", label: "PHP-FPM", service: "php8.2-fpm.service", status: "Aktywna", cssClass: "status-ok", details: nil),
+            ServiceStatus(id: "mosquitto.service", label: "MQTT", service: "mosquitto.service", status: "Błąd", cssClass: "status-error", details: "Process exited")
+        ]
+
+        let historyEntries: [HistoryEntry] = (0..<24).compactMap { index in
+            let date = Calendar.current.date(byAdding: .minute, value: -(23 - index) * 30, to: now)
+            return HistoryEntry(
+                generatedAt: date,
+                time: DateFormatter.localizedString(from: date ?? now, dateStyle: .none, timeStyle: .short),
+                cpuTemperature: .init(value: Double.random(in: 40...65), label: String(format: "%.1f °C", Double.random(in: 40...65))),
+                memoryUsage: .init(percentage: Double.random(in: 20...80), label: "3.2 / 8 GB"),
+                diskUsage: .init(percentage: Double.random(in: 40...70), label: "29 / 64 GB"),
+                systemLoad: .init(one: Double.random(in: 0.4...1.6), five: Double.random(in: 0.3...1.1), fifteen: Double.random(in: 0.2...0.8), label: "0.65, 0.55, 0.40")
+            )
+        }
+
+        let snapshot = StatusSnapshot(
+            time: DateFormatter.localizedString(from: now, dateStyle: .none, timeStyle: .medium),
+            generatedAt: now,
+            cpuTemperature: "52.1 °C",
+            systemLoad: "0.62, 0.55, 0.48",
+            uptime: "2 d 4 h 11 min",
+            memoryUsage: "3.4 / 8 GB (42%)",
+            diskUsage: "29 / 64 GB (45%)",
+            services: services
+        )
+
+        let history = HistoryPayload(
+            generatedAt: now,
+            enabled: true,
+            maxEntries: 360,
+            maxAge: nil,
+            count: historyEntries.count,
+            limit: 120,
+            entries: historyEntries
+        )
+
+        let shelly = ShellyPayload(
+            generatedAt: now,
+            count: 2,
+            hasErrors: false,
+            devices: [
+                ShellyDevice(id: "boiler", label: "Boiler", state: "on", description: "Włączone", error: nil, ok: true),
+                ShellyDevice(id: "gate", label: "Brama", state: "off", description: "Wyłączone", error: nil, ok: true)
+            ],
+            configError: false,
+            httpStatus: 200,
+            error: nil,
+            message: nil
+        )
+
+        return StatusBundle(
+            generatedAt: now,
+            streamInterval: 5,
+            snapshot: snapshot,
+            history: history,
+            shelly: shelly
+        )
+    }
+}

--- a/RoomPi/StatusService.swift
+++ b/RoomPi/StatusService.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+struct StatusService {
+    struct BasicCredentials {
+        let username: String
+        let password: String
+    }
+
+    enum ServiceError: LocalizedError {
+        case invalidURL
+        case invalidResponse
+        case httpError(statusCode: Int, message: String?)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidURL:
+                return "Nieprawidłowy adres usługi API."
+            case .invalidResponse:
+                return "Nieoczekiwana odpowiedź serwera."
+            case let .httpError(statusCode, message):
+                if let message, !message.isEmpty {
+                    return "Serwer zwrócił błąd (\(statusCode)): \(message)"
+                }
+                return "Serwer zwrócił błąd (\(statusCode))."
+            }
+        }
+    }
+
+    let baseURL: URL
+    var session: URLSession = .shared
+    var credentials: BasicCredentials?
+
+    func fetchStatusBundle(historyLimit: Int? = 120) async throws -> StatusBundle {
+        guard let requestURL = makeBundleURL(historyLimit: historyLimit) else {
+            throw ServiceError.invalidURL
+        }
+
+        var request = URLRequest(url: requestURL)
+        request.httpMethod = "GET"
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.timeoutInterval = 15
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        if let credentials {
+            let token = "\(credentials.username):\(credentials.password)"
+            if let data = token.data(using: .utf8) {
+                request.setValue("Basic \(data.base64EncodedString())", forHTTPHeaderField: "Authorization")
+            }
+        }
+
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ServiceError.invalidResponse
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            let payload = String(data: data, encoding: .utf8)
+            throw ServiceError.httpError(statusCode: httpResponse.statusCode, message: payload)
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        return try decoder.decode(StatusBundle.self, from: data)
+    }
+
+    private func makeBundleURL(historyLimit: Int?) -> URL? {
+        var bundleURL = baseURL
+
+        if bundleURL.pathExtension.lowercased() != "php" {
+            bundleURL.appendPathComponent("index.php")
+        }
+
+        var components = URLComponents(url: bundleURL, resolvingAgainstBaseURL: false)
+        var queryItems = [URLQueryItem(name: "status", value: "ios")]
+        if let historyLimit {
+            queryItems.append(URLQueryItem(name: "limit", value: String(historyLimit)))
+        }
+        components?.queryItems = queryItems
+
+        return components?.url
+    }
+}


### PR DESCRIPTION
## Summary
- replace the WKWebView wrapper with a fully native SwiftUI dashboard that consumes the RaspberryPiServer REST API
- add models, networking layer, and a view model to decode the `?status=ios` payload, handle refreshes, and expose derived state to the UI
- implement charts, service status cards, and Shelly device summaries designed for touch while reusing the server-side metrics

## Testing
- Not run (xcodebuild unavailable in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68d43f99651083319373f6054fad4780