### PR TITLE
Add Shelly device control from dashboard

### DIFF
--- a/RoomPi/StatusService.swift
+++ b/RoomPi/StatusService.swift
@@ -6,6 +6,16 @@ struct StatusService {
         let password: String
     }
 
+    struct ShellyCommandResponse: Decodable, Equatable {
+        let success: Bool?
+        let message: String?
+        let state: String?
+
+        static let successPlaceholder = ShellyCommandResponse(success: true, message: nil, state: nil)
+
+        var isSuccessful: Bool { success ?? true }
+    }
+
     enum ServiceError: LocalizedError {
         case invalidURL
         case invalidResponse
@@ -29,6 +39,12 @@ struct StatusService {
     let baseURL: URL
     var session: URLSession = .shared
     var credentials: BasicCredentials?
+
+    enum ShellyCommand: String {
+        case turnOn = "on"
+        case turnOff = "off"
+        case toggle
+    }
 
     func fetchStatusBundle(historyLimit: Int? = 120) async throws -> StatusBundle {
         guard let requestURL = makeBundleURL(historyLimit: historyLimit) else {
@@ -65,6 +81,50 @@ struct StatusService {
         return try decoder.decode(StatusBundle.self, from: data)
     }
 
+    func sendShellyCommand(deviceID: String, command: ShellyCommand, overrideURL: URL? = nil) async throws -> ShellyCommandResponse {
+        guard let requestURL = overrideURL ?? makeShellyCommandURL(deviceID: deviceID, command: command) else {
+            throw ServiceError.invalidURL
+        }
+
+        var request = URLRequest(url: requestURL)
+        request.httpMethod = "GET"
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.timeoutInterval = 10
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        if let credentials {
+            let token = "\(credentials.username):\(credentials.password)"
+            if let data = token.data(using: .utf8) {
+                request.setValue("Basic \(data.base64EncodedString())", forHTTPHeaderField: "Authorization")
+            }
+        }
+
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ServiceError.invalidResponse
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            let payload = String(data: data, encoding: .utf8)
+            throw ServiceError.httpError(statusCode: httpResponse.statusCode, message: payload)
+        }
+
+        guard !data.isEmpty else {
+            return .successPlaceholder
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        if let response = try? decoder.decode(ShellyCommandResponse.self, from: data) {
+            return response
+        }
+
+        let message = String(data: data, encoding: .utf8)
+        return ShellyCommandResponse(success: true, message: message, state: nil)
+    }
+
     private func makeBundleURL(historyLimit: Int?) -> URL? {
         var bundleURL = baseURL
 
@@ -78,6 +138,24 @@ struct StatusService {
             queryItems.append(URLQueryItem(name: "limit", value: String(historyLimit)))
         }
         components?.queryItems = queryItems
+
+        return components?.url
+    }
+
+    private func makeShellyCommandURL(deviceID: String, command: ShellyCommand) -> URL? {
+        var shellyURL = baseURL
+
+        if shellyURL.pathExtension.lowercased() == "php" {
+            shellyURL.deleteLastPathComponent()
+        }
+
+        shellyURL.appendPathComponent("shelly.php")
+
+        var components = URLComponents(url: shellyURL, resolvingAgainstBaseURL: false)
+        components?.queryItems = [
+            URLQueryItem(name: "device", value: deviceID),
+            URLQueryItem(name: "command", value: command.rawValue)
+        ]
 
         return components?.url
     }


### PR DESCRIPTION
## Summary
- enable Shelly device tiles to expose toggle buttons, loading feedback and error messaging
- manage Shelly relay commands in the dashboard view model, including optional per-device override URLs
- extend the data model and service layer to decode Shelly control metadata and call the control API

## Testing
- not run (requires iOS build environment)


------
https://chatgpt.com/codex/tasks/task_e_68d4453b23c08331adae3e99b0a70b6f