### PR TITLE
Handle alternate Shelly state values

### DIFF
--- a/RoomPi/StatusModels.swift
+++ b/RoomPi/StatusModels.swift
@@ -149,7 +149,18 @@ struct ShellyDevice: Decodable, Identifiable, Equatable {
     let supportsControl: Bool?
 
     var isOn: Bool {
-        state.lowercased() == "on"
+        let normalizedState = state
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        switch normalizedState {
+        case "on", "true", "1", "open":
+            return true
+        case "off", "false", "0", "close", "closed":
+            return false
+        default:
+            return normalizedState.hasPrefix("on")
+        }
     }
 
     var allowsControl: Bool {


### PR DESCRIPTION
## Summary
- normalize Shelly state values to better reflect the physical device status
- treat additional Shelly responses such as true/false and 1/0 as valid on/off indicators

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d4595089fc8331bb8b983a233ed0d8