### PR TITLE
Make web content span full application window

### DIFF
--- a/RoomPi/AdaptiveWebView.swift
+++ b/RoomPi/AdaptiveWebView.swift
@@ -43,6 +43,8 @@ struct AdaptiveWebView: UIViewRepresentable {
         webView.navigationDelegate = context.coordinator
         webView.allowsBackForwardNavigationGestures = true
         webView.scrollView.contentInsetAdjustmentBehavior = .never
+        webView.scrollView.contentInset = .zero
+        webView.scrollView.scrollIndicatorInsets = .zero
 
         context.coordinator.connect(webView: webView, userContentController: userContentController)
         context.coordinator.loadIfNeeded()

--- a/RoomPi/ContentView.swift
+++ b/RoomPi/ContentView.swift
@@ -9,6 +9,7 @@ struct ContentView: View {
     var body: some View {
         ZStack {
             AdaptiveWebView(url: dashboardURL, themeObserver: themeObserver)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .ignoresSafeArea()
 
             if themeObserver.isLoading {
@@ -18,7 +19,8 @@ struct ContentView: View {
                     .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
             }
         }
-        .background(Color(.systemBackground))
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemBackground).ignoresSafeArea())
         .preferredColorScheme(themeObserver.colorScheme)
     }
 }


### PR DESCRIPTION
## Summary
- ensure the embedded web view removes automatic insets and occupies the full window width
- expand the SwiftUI layout to stretch across the available space and extend the background through the safe area

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d52d795ad48331ad6c6d35a09e571a